### PR TITLE
Servo Completed: Merge into development in prep for pool test

### DIFF
--- a/ros/src/i2c/scripts/imu_proc.py
+++ b/ros/src/i2c/scripts/imu_proc.py
@@ -127,6 +127,7 @@ if __name__ == "__main__":
             R = Q * T1
             rads = euler_from_quaternion(Q.elements)
             out_message.header.stamp = rospy.Time.now()
+            out_message.header.frame_id = "/IMU_euler"
             out_message.gyro
             for i in range(0,3):
                 out_message.gyro[i] = rads[i] * 180.0 / 3.1415

--- a/ros/src/i2c/scripts/servo_listener.py
+++ b/ros/src/i2c/scripts/servo_listener.py
@@ -1,73 +1,116 @@
 #! /usr/bin/env python3
 
+#set servo angle to certain value and test to see if imu works with moving angle
+#then test without imu to see if actual servo has basic functionality
+#then test with imu enabled to see servo will actually move with it
+#then hook up to front end and see what clicking lock and unlock mid difference does
+
+
 #Notes:
 #This scripts takes an input of 0-180 degrees from the test servo publisher node
 # It uses a math equation to translate this value into a number with a range of 1-12
 #The servo specifications indicate a duty cycle of 1-2ms with a total period of 20ms. This would indicate a duty cycle from 5-10 percentage wise.
-#However for some reason testing hardcoded values found that it takes 1-12 percent for a full range of 180 degree motion for some reason
+#However for some reason testing hardcoded values found that it takes 1-12 value for a full range of 180 degree motion for some reason
 #that's not mathmatically correct but it works so eh
 #duty cycle(6) for in the middle. duty cycle(0) is off
 #for this inclosure the input can be 12 to 120 degrees. the code will automatically make these the max values
 
-import rospy
-from std_msgs.msg import Float32
-import RPi.GPIO as GPIO #imports the standard Raspberry Pi GPIO library
-import time
-from time import sleep #imports sleep (aka waiting or pause) into the program
 
-#Setting a Pin Mode
-GPIO.setmode(GPIO.BCM) #Chose Board pin number scheme
+#import statements
+##import RPi.GPIO as GPIO #imports the standard Raspberry Pi GPIO library
+import rospy
+from time import sleep #imports sleep (aka waiting or pause) into the program
+import message_filters
+from shared_msgs.msg import servo_msg, imu_msg
+
+#Coverts angle to duty cycle, need to update values here
+def angleToDuty(angle): 
+    duty = ((angle /180) * 11) + 1 #converts to duty cycle
+    return duty
+
+#initialization
+GPIO.setmode(GPIO.BCM) #Setting a Pin Mode aka Chose Board pin number scheme
 #Set up pin 14 for PWM
 GPIO.setup(13, GPIO.OUT) #sets up pin 13 to an output
 p = GPIO.PWM(13,50) #sets up pin 13 as a PWM pin(50 is the frequency)
 p.start(0) #starts running PWM on the pin and sets it to 0. 0 is the middle
-duty_prev = 5.8 #sets to middle duty cycle this is the "middle"
+angle_prev = 90 #sets to middle angle
+duty_prev = angleToDuty(angle_prev)
+lockSet = 0
+imuPitchRef = 0
 p.ChangeDutyCycle(duty_prev)
 sleep(0.04) #max time delay
 p.ChangeDutyCycle(0)
 
-def callback(requestedAngle):
+def callback(servoStuff, imuStuff):
+    #print(servoStuff)
+    #print(imuStuff)
+    global angle_prev
     global duty_prev
-    rate = rospy.Rate(100)  
-    #change the angle to desired duty cycle
-    duty = ((requestedAngle.data /180) * 11) + 1 #the range of the servo is dutycycle of 1-12 for some reason. So this formula should take in angle of 0-180 and transfer the value from 1-12
-    #caps the duty cycle to the max angle values
-    if duty > 18.02:
-       duty = 8.02
-    elif duty < 0.02:
-       duty = 2.02
-    
-    dutyDiff = abs(duty_prev - duty)
-    timeToWait = (12.5*(dutyDiff**0.515)+10)/1000
+    global lockSet
+    global imuPitchRef
+    imuPitchDiff = 0
 
-    #only run if new number
-    if (duty != duty_prev):
-        try:
-            print(f"Current Duty: {duty:.4f}")
-            print(f"Prev Duty: {duty_prev:.4f}")
-            print(f"Duty Diff = {dutyDiff:.6f} and timeToWait = {timeToWait:.6f}\n")
-            #Debug code for testing a varity of values to test full range of motion
-            #it = [8.02, 2.02, 8.02, 6.5, 7.5, 6.5, 6.6, 6.5, 2.02]  #OKAY so for some reason a duty cycle of 1-12 is used to get a full 180 degrees of rotation. even tho that data sheet indicats 5-10
-            #for i in it:
-            #   print(f"Current Duty Cycle: {i}")
-            #   p.ChangeDutyCycle(i)
-            #   time.sleep(2.0)
-            #print("finished diognostic")
-            p.ChangeDutyCycle(duty)
-            duty_prev = duty
-        except:
-            print("there has been some error of some type :/")
-    sleep(timeToWait) #this is so the servo pauses before turning off the power
-    p.ChangeDutyCycle(0) #if the servo jitters a lot uncomment this it should stop all movement in between calls
+    if(servoStuff.servo_lock_status == True):
+        if(lockSet == 0):
+            imuPitchRef = imuStuff.gyro[1]
+            lockSet = 1
+            print(f"lock has been set. imupitchRef = {imuPitchRef}")
+        imuPitchDiff = imuPitchRef - imuStuff.gyro[1] #might have to switch this to be the other way around
+        print(f'imuPitchDiff has been found = {imuPitchDiff}')
+    else:
+        lockSet = 0
+        print("lock has been unset")
+
+    adjustedAngle = servoStuff.angle + imuPitchDiff
+    if adjustedAngle > 180:
+        adjustedAngle = 180
+    elif adjustedAngle < 0:
+        adjustedAngle = 0
     
+    if (adjustedAngle != angle_prev):
+        adjustedDuty = angleToDuty(adjustedAngle)
+
+        dutyDiff = abs(duty_prev - adjustedDuty)
+        timeToWait = (12.5*(dutyDiff**0.515)+10)/1000
+      
+        
+        print(f'Old Adjusted angle: {angle_prev}')
+        print(f'Old Adjusted duty: {duty_prev}') 
+        print(f'Adjusted angle: {adjustedAngle}')
+        print(f'Adjusted duty: {adjustedDuty}')
+        print("\n") 
+        p.ChangeDutyCycle(adjustedDuty)
+        duty_prev = adjustedDuty
+        angle_prev = adjustedAngle  
+        sleep(timeToWait) #this is so the servo pauses before turning off the power
+        p.ChangeDutyCycle(0) #if the servo jitters a lot uncomment this it should stop all movement in between calls
+
+
+
+
+
+
 
 def listener():
-    rospy.init_node('servo_listener_node', anonymous=True)
-    rospy.Subscriber("servo", Float32, callback)
-    #rospy.Subscriber("test_servor_angle", Float32, callback)
-    rospy.spin() #keeps python from exiting until this node is stopped 
+
+    # In ROS, nodes are uniquely named. If two nodes with the same
+    # name are launched, the previous one is kicked off. The
+    # anonymous=True flag means that rospy will choose a unique
+    # name for our 'listener' node so that multiple listeners can
+    # run simultaneously.
+         
+    servoStuff = message_filters.Subscriber('ServoAngles', servo_msg)
+    imuStuff = message_filters.Subscriber('IMUvalues', imu_msg)
+    
+    combined = message_filters.ApproximateTimeSynchronizer([servoStuff, imuStuff], 1, slop=10000)
+    combined.registerCallback(callback)
+    rospy.spin() # spin() simply keeps python from exiting until this node is stopped
+    
+    print("shutting down servo node")
+
 
 if __name__ == '__main__':
-    #subscribe to the can hardware transmitter
+    rospy.init_node('listener', anonymous=True)
     listener()
-
+    

--- a/ros/src/i2c/scripts/servo_talker.py
+++ b/ros/src/i2c/scripts/servo_talker.py
@@ -1,37 +1,24 @@
-#! /usr/bin/env python3
-
+#! /usr/bin/python3
 import rospy
 import time
 from std_msgs.msg import Float32
-#from shared_msgs.msg import servo_msg
+from shared_msgs.msg import servo_msg
 
 def talker():
-    rospy.init_node('servo_debug_talker_node', anonymous=True)
-    pub = rospy.Publisher('servo', Float32, queue_size=10)
-    rate = rospy.Rate(10) #10Hz
-    i = 0
-        
+    rospy.init_node('other_talker', anonymous=True)
+    pub = rospy.Publisher('ServoAngles', servo_msg, queue_size=10)
+    rate = rospy.Rate(10) # 10hz
     while not rospy.is_shutdown():
+        servoCam = servo_msg()
+        servoCam.angle =  float(input("Insert desired angle: "))
+        servoCam.servo_lock_status = False
+        servoCam.header.stamp = rospy.Time.now()
+        servoCam.header.frame_id = "/ServoTest"
         
-        #servoCam = servo_msg()
-        servoCam = float(input("Insert desired angle: "))
-        #servoCam.servo_lock_status = False #might have to be false
-        #servoCam.header.stamp = rospy.Time.now() #also might have to include
-        #servoCam.header.frame_id = "/ServoTest" #might have to include
-
-        pub.publish(servoCam)        
-
-        #if i%2 == 0:
-        #    angle = 0.0
-        #    print(angle)
-        #    pub.publish(angle)
-        #else:
-        #    angle = 180.0
-        #    print(angle)
-        #    pub.publish(angle)
-        #i += 1
-
-        #time.sleep(4)
+        print(servoCam)
+        rospy.loginfo(servoCam)
+        pub.publish(servoCam)
+        rate.sleep()   
 
 if __name__ == '__main__':
     try:

--- a/ros/src/i2c/scripts/servo_talker.py
+++ b/ros/src/i2c/scripts/servo_talker.py
@@ -10,7 +10,7 @@ def talker():
     rate = rospy.Rate(10) # 10hz
     while not rospy.is_shutdown():
         servoCam = servo_msg()
-        servoCam.angle =  float(input("Insert desired angle: "))
+        servoCam.angle = float(input("Insert desired angle: "))
         servoCam.servo_lock_status = False
         servoCam.header.stamp = rospy.Time.now()
         servoCam.header.frame_id = "/ServoTest"


### PR DESCRIPTION
The servo completely works now.

In the servo listener python file, you can easily change the MAX_ANGLE and MIN_ANGLE if you need to update them.

Controlling the servo requires data from the servo_msg and imu_msg.

To control the servo from the front end, use the custom msg servo_msg and send as "ServoAngles" topic name. Send float32 angle _and_ the bool servo_lock_status. You can also manually control with the talker script.

servo_lock_status = False will mean you manually control the servo and set the angle. If you set this to True, the servo will take into account data from the imu to automatically keep the servo level. 

